### PR TITLE
Fix bug concerning null ApiRateLimit instance in RateLimitHandler

### DIFF
--- a/Service/RateLimitHandler.php
+++ b/Service/RateLimitHandler.php
@@ -151,7 +151,9 @@ class RateLimitHandler
 
         if (null !== $annotation) {
             $this->enabled = $annotation->enabled;
-        }
+        } else {
+	    $annotation = new ApiRateLimit();
+	}
 
         list($key, $limit, $period) = $this->getThrottle($request, $annotation);
 

--- a/Service/RateLimitHandler.php
+++ b/Service/RateLimitHandler.php
@@ -152,8 +152,8 @@ class RateLimitHandler
         if (null !== $annotation) {
             $this->enabled = $annotation->enabled;
         } else {
-	    $annotation = new ApiRateLimit();
-	}
+            $annotation = new ApiRateLimit();
+        }
 
         list($key, $limit, $period) = $this->getThrottle($request, $annotation);
 


### PR DESCRIPTION
When using the `master` version, the following error occurs: 

```
Argument 2 passed to Indragunawan\\ApiRateLimitBundle\\Service\\RateLimitHandler::getThrottle() must be an instance of Indragunawan\\ApiRateLimitBundle\\Annotation\\ApiRateLimit, null given, called in /var/www/html/vendor/indragunawan/api-rate-limit-bundle/Service/RateLimitHandler.php on line 157
```

The responsible lines are:
 
https://github.com/IndraGunawan/api-rate-limit-bundle/blob/1096ebfe1b181d6b6e38ccf58884ab871b41c47b/Service/RateLimitHandler.php#L152-L156

Indeed, if `$annotation` is `null`, the `getThrottle` method fails. It's why creating a new instance of `ApiRateLimit` is required if this case.