### PR TITLE
 Support request methods selection

### DIFF
--- a/Annotation/ApiRateLimit.php
+++ b/Annotation/ApiRateLimit.php
@@ -28,4 +28,10 @@ final class ApiRateLimit
      * @var array
      */
     public $throttle = [];
+
+    /**
+     * @var array
+     * @example ["GET", "POST"]
+     */
+    public $methods = [];
 }

--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -101,6 +101,7 @@ Configuration per resource
 -------------------------------
 
 If you wish to configure the rate limits differently on some resources, you can use the `ApiRateLimit` annotation and set the `throttle` property in the same way you do in your main configuration.
+You can define a rate limits only for some specific methods using `methods` property (by default `null` to cover all the different methods).
 You can also choose to enable or disable rate limiting by using the `enabled` property.
 
 ```php
@@ -128,7 +129,8 @@ use Indragunawan\ApiRateLimitBundle\Annotation\ApiRateLimit;
  *                 "period"=10
  *             }
  *         }
- *     }
+ *     },
+ *     methods={"GET", "DELETE"}
  * )
  */
 class Foo

--- a/Service/RateLimitHandler.php
+++ b/Service/RateLimitHandler.php
@@ -151,7 +151,9 @@ class RateLimitHandler
 
         if (null !== $annotation) {
             $this->enabled = $annotation->enabled;
-        }
+        } else {
+	    $annotation = new ApiRateLimit();
+	}
 
         list($key, $limit, $period) = $this->getThrottle($request, $annotation);
 

--- a/Service/RateLimitHandler.php
+++ b/Service/RateLimitHandler.php
@@ -151,6 +151,10 @@ class RateLimitHandler
 
         if (null !== $annotation) {
             $this->enabled = $annotation->enabled;
+            if(!in_array($request->getMethod(), array_map('strtoupper', $annotation->methods)) &&  !empty($annotation->methods)) {
+                // The annotation is ignored as the method is not corresponding
+                $annotation = new ApiRateLimit();
+            }
         } else {
 	    $annotation = new ApiRateLimit();
 	}


### PR DESCRIPTION
Thanks to this PR, it's possible selecting to which specific methods the rate limit is applied:

```php
/**
 * @ApiResource
 * @ORM\Entity
 * @ApiRateLimit(
 *     enabled=true, 
 *     throttle={
 *         "default"={
 *             "limit"=2,
 *             "period"=10
 *         }
 *     }
 *     },
 *     methods={"GET", "DELETE"}
 * )
 */
class Foo {

}
```

If the method is not corresponding to the annotation ones (e.g `POST`), then it's the global configuration rate limit that is applied.

*Notes: this PR is based on the following fix: https://github.com/IndraGunawan/api-rate-limit-bundle/pull/11*
