### PR TITLE
Enable rate limiting based on API Operations annotations

### DIFF
--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -101,7 +101,7 @@ Configuration per resource
 -------------------------------
 
 If you wish to configure the rate limits differently on some resources, you can use the `ApiRateLimit` annotation and set the `throttle` property in the same way you do in your main configuration.
-You can define a rate limits only for some specific methods using `methods` property (by default `null` to cover all the different methods).
+You can define a rate limits only for some specific methods using `methods` property (by default `null` to cover all the different methods). You may also use api operation names in your list of methods.
 You can also choose to enable or disable rate limiting by using the `enabled` property.
 
 ```php

--- a/Service/RateLimitHandler.php
+++ b/Service/RateLimitHandler.php
@@ -123,7 +123,7 @@ class RateLimitHandler
      * @throws \Psr\Cache\InvalidArgumentException
      * @throws \ReflectionException
      */
-    public function handle(Request $request)
+     public function handle(Request $request)
     {
         $annotationReader = new AnnotationReader();
         /** @var ApiRateLimit $annotation */
@@ -134,7 +134,13 @@ class RateLimitHandler
 
         if (null !== $annotation) {
             $this->enabled = $annotation->enabled;
-            if (!\in_array($request->getMethod(), array_map('strtoupper', $annotation->methods), true) && !empty($annotation->methods)) {
+            if ((
+                    !\in_array($request->getMethod(), array_map('strtoupper', $annotation->methods), true)
+                    &&
+                    !\in_array($request->attributes->get('_api_item_operation_name'),array_map('strtolower', $annotation->methods),true)
+                )
+                && !empty($annotation->methods)
+            ) {
                 // The annotation is ignored as the method is not corresponding
                 $annotation = new ApiRateLimit();
             }


### PR DESCRIPTION
API Platform allows special actions to be added to entity-backed endpoints. (https://api-platform.com/docs/core/controllers/#creating-custom-operations-and-controllers), which can easily be used for special operations on an entity. For example, this might be used to flag a Product or Customer for administrative review, or to manage a publication action. In this case, a developer might wish to rate-limit this reporting mechanism, but not all actions on the endpoint using the same HTTP verb (GET, PUT, DELETE, etc).

A relevant bit of the example annotation might look something like:
```
/**
 * @ApiResource(itemOperations={
 *     "get",
 *     "flag_product"={
 *         "method"="GET",
 *         "path"="/books/{id}/flag",
 *         "controller"=FlagEntity::class,
 *     }
 * })
 */
 ```

In this case, we wish to rate limit only the `flag_product` entry, not the regular GET operation on the entity. Because this information is available to the Request as one of its attributes, `_api_item_operation_name`, we can check for this when deciding upon rate limiting.

This PR offers a simple approach to incorporating this information into the existing RateLimitHandler.

